### PR TITLE
ヘッダー・トップページにリンクを追加

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -6,15 +6,21 @@ type ButtonProps = {
   textColor: string;
   bgColor: string;
   className?: string;
+  labelClassName?: string;
 };
 
 export const Button: FC<ButtonProps> = (props) => {
   return (
     <button
       type="button"
-      className={clsx(["font-bold rounded-full px-10 py-4 w-fit", props.textColor, props.bgColor, props.className])}
+      className={clsx([
+        "group font-bold rounded-full px-10 py-4 w-fit",
+        props.textColor,
+        props.bgColor,
+        props.className,
+      ])}
     >
-      {props.label}
+      <span className={props.labelClassName}>{props.label}</span>
     </button>
   );
 };

--- a/src/components/ui/Layout/Header/Header.tsx
+++ b/src/components/ui/Layout/Header/Header.tsx
@@ -1,11 +1,16 @@
 import type { FC } from "react";
+import Link from "next/link";
 import { Logo } from "~/components/ui/Layout/Header/Logo";
 import { HeaderMenu } from "~/components/ui/Layout/Header/HeaderMenu";
 
 export const Header: FC = () => {
   return (
-    <header className="px-10 w-full h-16 items-center flex justify-between">
-      <Logo />
+    <header className="bg-white px-10 w-full h-16 items-center flex justify-between drop-shadow">
+      <Link href="/">
+        <a className="hover:opacity-80">
+          <Logo />
+        </a>
+      </Link>
       <HeaderMenu />
     </header>
   );

--- a/src/components/ui/Layout/Header/HeaderMenu.tsx
+++ b/src/components/ui/Layout/Header/HeaderMenu.tsx
@@ -5,9 +5,9 @@ export const HeaderMenu: FC = () => {
   return (
     <nav>
       <ul className="flex gap-x-8">
-        <HeaderMenuItem title="サービス" />
-        <HeaderMenuItem title="プロフィール" />
-        <HeaderMenuItem title="お問い合わせ" />
+        <HeaderMenuItem title="サービス" url="/service" />
+        <HeaderMenuItem title="プロフィール" url="/profile" />
+        <HeaderMenuItem title="お問い合わせ" url="/contact" />
       </ul>
     </nav>
   );

--- a/src/components/ui/Layout/Header/HeaderMenuItem.tsx
+++ b/src/components/ui/Layout/Header/HeaderMenuItem.tsx
@@ -1,9 +1,24 @@
 import type { FC } from "react";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import clsx from "clsx";
 
 type HeaderMenuItemProps = {
   title: string;
+  url: string;
 };
 
 export const HeaderMenuItem: FC<HeaderMenuItemProps> = (props) => {
-  return <li className="font-bold text-sm cursor-pointer">{props.title}</li>;
+  const router = useRouter();
+  const textColor = router.pathname === props.url ? "text-red" : "";
+  const hoverOpacity =
+    router.pathname === props.url ? "hover:opacity-80" : "hover:opacity-70";
+
+  return (
+    <li className="font-bold text-sm cursor-pointer">
+      <Link href={props.url}>
+        <a className={clsx([textColor, hoverOpacity])}>{props.title}</a>
+      </Link>
+    </li>
+  );
 };

--- a/src/components/ui/Layout/Layout.tsx
+++ b/src/components/ui/Layout/Layout.tsx
@@ -9,7 +9,9 @@ type LayoutProps = {
 export const Layout: FC<LayoutProps> = (props) => {
   return (
     <div>
-      <Header />
+      <div className="sticky top-0 z-50">
+        <Header />
+      </div>
       <main>{props.children}</main>
       <Footer />
     </div>

--- a/src/pages/contact.page.tsx
+++ b/src/pages/contact.page.tsx
@@ -1,0 +1,11 @@
+import type { NextPage } from "next";
+import { Layout } from "~/components/ui/Layout/Layout";
+
+const ContactPage: NextPage = () => {
+  return (
+    <Layout>
+      <h1>お問い合わせ</h1>
+    </Layout>
+  );
+};
+export default ContactPage;

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -1,6 +1,12 @@
 import type { NextPage } from "next";
+import Link from "next/link";
 import { Layout } from "~/components/ui/Layout/Layout";
-import { PeopleIcon, TrendingUpIcon, GraphIcon, DirectionIcon } from "~/components/ui/Icons";
+import {
+  PeopleIcon,
+  TrendingUpIcon,
+  GraphIcon,
+  DirectionIcon,
+} from "~/components/ui/Icons";
 import { Feature } from "~/components/ui/Feature";
 import { TableRow } from "~/components/ui/TableRow";
 import { Button } from "~/components/ui/Button";
@@ -36,7 +42,7 @@ const businessSummary = [
       "ウェブ解析士個人認定資格",
       "Google アナリティクス個人認定資格",
       "CEFR C1（TOEIC940点相当）",
-    ].join("\n")
+    ].join("\n"),
   },
 ];
 
@@ -55,12 +61,23 @@ const Home: NextPage = () => {
             <br />
             Webサイトを「価値のある資産」にし、ビジネスを活性化させていきましょう。
           </div>
-          <Button label="無料で相談してみる" textColor="text-black" bgColor="bg-white" />
+          <Link href="/contact">
+            <a className="">
+              <Button
+                label="無料で相談してみる"
+                textColor="text-black"
+                bgColor="bg-white"
+                labelClassName="group-hover:opacity-70"
+              />
+            </a>
+          </Link>
         </div>
       </section>
 
       <section className="py-20 flex flex-col items-center">
-        <h1 className="font-bold text-3xl text-center mb-10">Webでのこんなお悩みを解決します</h1>
+        <h1 className="font-bold text-3xl text-center mb-10">
+          Webでのこんなお悩みを解決します
+        </h1>
         <div className="flex gap-x-16">
           <Feature
             icon={<PeopleIcon />}
@@ -89,12 +106,18 @@ const Home: NextPage = () => {
           まで繋げていきます。
           <br />
           精密な
-          <span className="font-bold">「クライント企業様の調査」「競合分析」「アクセス解析」</span>
+          <span className="font-bold">
+            「クライント企業様の調査」「競合分析」「アクセス解析」
+          </span>
           <br />
           これらを基に戦略を決め、 実行までサポートさせていただきます。
           <br />
           具体的なサービス内容は
-          <span className="text-red underline cursor-pointer mx-0.5">サービスページ</span>
+          <Link href="/service">
+            <a className="text-red underline hover:opacity-80 cursor-pointer mx-0.5">
+              サービスページ
+            </a>
+          </Link>
           をご覧いただけますと幸いです。
         </div>
       </section>

--- a/src/pages/profile.page.tsx
+++ b/src/pages/profile.page.tsx
@@ -1,0 +1,11 @@
+import type { NextPage } from "next";
+import { Layout } from "~/components/ui/Layout/Layout";
+
+const ProfilePage: NextPage = () => {
+  return (
+    <Layout>
+      <h1>プロフィール</h1>
+    </Layout>
+  );
+};
+export default ProfilePage;

--- a/src/pages/service.page.tsx
+++ b/src/pages/service.page.tsx
@@ -1,0 +1,11 @@
+import type { NextPage } from "next";
+import { Layout } from "~/components/ui/Layout/Layout";
+
+const ServicePage: NextPage = () => {
+  return (
+    <Layout>
+      <h1>サービス</h1>
+    </Layout>
+  );
+};
+export default ServicePage;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -6,8 +6,8 @@ html,
 body {
   padding: 0;
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,
-    Helvetica Neue, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
   line-height: 1.6;
   font-size: 16px;
 }
@@ -17,12 +17,8 @@ body {
 }
 
 a {
-  color: #0070f3;
+  color: black;
   text-decoration: none;
-}
-
-a:hover {
-  text-decoration: underline;
 }
 
 img {


### PR DESCRIPTION
- 以下のページを作成
  - サービスページ
  - プロフィールページ
  - お問い合わせ
- 以下の箇所にリンクを追加
  - ヘッダーのロゴ
  - ヘッダーのメニュー
  - トップページ上部の「無料で相談してみる」ボタン
  - トップページ中央のサービスページへの導線
- ヘッダーのスタイルを変更